### PR TITLE
Email notification and Info for Editors

### DIFF
--- a/blueprints/fields/form-email-info.yml
+++ b/blueprints/fields/form-email-info.yml
@@ -1,0 +1,10 @@
+label:
+  de: Info
+  en: Info
+type: info
+
+text:
+  de: Es ist notwendig, ein Feld mit der Bezeichnung "email" zu haben. Das heißt, der **Identifier** eines E-Mail-Feldes in Ihrem Formular muss "email" lauten.
+  en: It is necessary to have a field called „email“. Meaning the **Identifier** of an email field in your form needs say „email“.
+when:
+  confirmationEmail_enabled: true

--- a/blueprints/sections/form-confirmation-email.yml
+++ b/blueprints/sections/form-confirmation-email.yml
@@ -23,6 +23,10 @@ fields:
     when:
       confirmationEmail_enabled: true
 
+  confirmationEmail_info: 
+    extends: fields/form-email-info
+    theme: negative
+
   confirmationEmail_subject:
     type: text
     label:

--- a/blueprints/sections/form-fields.yml
+++ b/blueprints/sections/form-fields.yml
@@ -1,3 +1,6 @@
 type: fields
 fields:
+  confirmationEmail_form_info: 
+    extends: fields/form-email-info
+    theme: negative
   form_fields: fields/form-fields

--- a/blueprints/sections/form-notification-email.yml
+++ b/blueprints/sections/form-notification-email.yml
@@ -14,6 +14,7 @@ fields:
     width: 2/12
 
   notificationEmail_to:
+    type: email
     extends: fields/form-email-sender
     label:
       *: arnoson.kirby-forms.email-to


### PR DESCRIPTION
fix: Email notification Email-to change type to email
refactor: Info for none coding Editors, who needs to know the uniform naming conventions.