### PR TITLE
Bugfix: If page doesn't exist (yet) return empty array

### DIFF
--- a/blueprints/form-entries.php
+++ b/blueprints/form-entries.php
@@ -6,6 +6,10 @@ return function ($kirby) {
   $slug = str_replace('+', '/', $result[1]);
   $formPage = page($slug) ?? site()->index()->drafts()->find($slug);
 
+  if (null === $formPage) {
+    return [];
+  }
+  
   $fields = kirbyForms()->formFields($formPage);
   $columns = array_reduce(
     array_slice($fields, 0, 4),


### PR DESCRIPTION
Currently the plugin fails if there's no form yet (see attachment).
This fix checks if there an page to begin with (on page creation in the dialog).
Since `kirbyForms()->formFields()` only accepts an page and not null.

If not; just return an empty array. 
<img width="1146" alt="Screenshot 2024-10-09 at 12 29 27" src="https://github.com/user-attachments/assets/1287eb59-1397-43fb-a193-b289104690d0">
