### PR TITLE
Duplicate key in nl.yml

### DIFF
--- a/translations/nl.yml
+++ b/translations/nl.yml
@@ -20,7 +20,7 @@ arnoson.kirby-forms.default: Standaard
 arnoson.kirby-forms.max-length: Maximale lengte
 arnoson.kirby-forms.min-length: Minimale lengte
 arnoson.kirby-forms.max-value: Maximale waarde
-arnoson.kirby-forms.max-value: Minimale waarde
+arnoson.kirby-forms.min-value: Minimale waarde
 arnoson.kirby-forms.pattern: Patroon
 arnoson.kirby-forms.placeholder: Placeholder
 arnoson.kirby-forms.contact: Contact


### PR DESCRIPTION
Symfony\Component\Yaml\Exception\ParseException thrown with message "Duplicate key "arnoson.kirby-forms.max-value" detected at line 23 (near "arnoson.kirby-forms.max-value: Minimale waarde")."

This fixes the typo