### PR TITLE
fix: disable creating an entry from the panel

### DIFF
--- a/blueprints/form-entries.php
+++ b/blueprints/form-entries.php
@@ -43,6 +43,7 @@ return function ($kirby) {
         'image' => false,
         'columns' => $columns,
         'sortBy' => 'form_submitted desc',
+        'create' => false,
       ],
     ],
   ];


### PR DESCRIPTION
Adding an entry from the form_entries section in the form-entries tab seems to be not possible. Panel displays an error `Call to a member function blueprints() on null`.

Disabling the Add button for the time being.