### PR TITLE
fix: entry options

### DIFF
--- a/blueprints/form-entry.php
+++ b/blueprints/form-entry.php
@@ -16,6 +16,9 @@ return function ($kirby) {
       'changeSlug' => false,
       'changeTitle' => false,
       'changeTemplate' => false,
+      'changeStatus' => false,
+      'duplicate' => false,
+      'move' => false,
     ],
     'type' => 'fields',
     'fields' => [

--- a/blueprints/form-entry.php
+++ b/blueprints/form-entry.php
@@ -16,7 +16,6 @@ return function ($kirby) {
       'changeSlug' => false,
       'changeTitle' => false,
       'changeTemplate' => false,
-      'changeStatus' => false,
       'duplicate' => false,
       'move' => false,
     ],


### PR DESCRIPTION
I guess an entry should only be able to be opened and deleted. 

Disabled changeStatus, duplicate, move options.