### PR TITLE
fix: form_success options

### DIFF
--- a/blueprints/form-email-template.php
+++ b/blueprints/form-email-template.php
@@ -11,7 +11,7 @@ return function (\Kirby\Cms\App $kirby) {
   );
 
   return [
-    'label' => 'Template',
+    'label' => t('arnoson.kirby-forms.template', 'template'),
     'type' => 'select',
     'options' => $templates,
   ];

--- a/blueprints/sections/form-confirmation-email.yml
+++ b/blueprints/sections/form-confirmation-email.yml
@@ -44,10 +44,10 @@ fields:
     width: 1/3
     options:
       - value: text
-        text: Text
+        text: "{{ t('arnoson.kirby-forms.text') }}"
         icon: text
       - value: template
-        text: template
+        text: "{{ t('arnoson.kirby-forms.template') ?? t('template') }}"
         icon: template
     when:
       confirmationEmail_enabled: true

--- a/blueprints/sections/form-notification-email.yml
+++ b/blueprints/sections/form-notification-email.yml
@@ -45,10 +45,10 @@ fields:
     width: 1/3
     options:
       - value: text
-        text: Text
+        text: "{{ t('arnoson.kirby-forms.text') }}"
         icon: text
       - value: template
-        text: template
+        text: "{{ t('arnoson.kirby-forms.template') ?? t('template') }}"
         icon: template
     when:
       notificationEmail_enabled: true

--- a/blueprints/sections/form-success.yml
+++ b/blueprints/sections/form-success.yml
@@ -12,12 +12,10 @@ fields:
     default: message
     options:
       - value: message
-        text:
-          *: arnoson.kirby-forms.message
+        text: "{{ t('arnoson.kirby-forms.message') }}"
         icon: text
       - value: page
-        text:
-          *: arnoson.kirby-forms.page
+        text: "{{ t('arnoson.kirby-forms.page') }}"
         icon: share
 
   success_text:


### PR DESCRIPTION
Settings section was erroring out with `Invalid section type ("form_success")`