### PR TITLE
Kirby 5 compatibility fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "arnoson/kirby-forms",
-  "description": "Form builder and handler for Kirby 3",
-  "version": "0.7.2",
+  "description": "Form builder and handler for Kirby 5",
+  "version": "0.7.3",
   "type": "kirby-plugin",
   "license": "MIT",
   "authors": [
@@ -14,7 +14,7 @@
     "mzur/kirby-uniform": "^5.3"
   },
   "require-dev": {
-    "getkirby/cms": "^4.0"
+    "getkirby/cms": "^5.0"
   },
   "config": {
     "allow-plugins": {

--- a/index.php
+++ b/index.php
@@ -70,7 +70,9 @@ function kirbyForms() {
       // uses a field with the same name in a non-form page.
       // TODO: find better way detect form pages (e.g. the page is a descendant of the forms page).
       if ($values['form_fields'] ?? false) {
-        $layouts = Layouts::factory(json_decode($values['form_fields'], true));
+        $formFieldsValue = $values['form_fields'];
+        $formFieldsArray = is_string($formFieldsValue) ? json_decode($formFieldsValue, true) : $formFieldsValue;
+        $layouts = Layouts::factory($formFieldsArray);
         $keys = [];
         foreach ($layouts as $layout) {
           foreach ($layout->columns() as $column) {


### PR DESCRIPTION
Kirby 5 newly sends $values['form_fields'] as Array. A check is now made and json_decode only executed if the data is not an Array yet. The code should be compatible with both Kirby 4 and 5.